### PR TITLE
Ensure that 1K rule for languages with no formatting return original number

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Short number formatting based on CLDR locale data.  Particularly useful for __st
 - `101234` is converted to `101K` in English and `101.1K` if need 1 significant digit
 - `1234` is converted to `1 mil` in Espanol
 - `101234` is converted to `101,1 mil` in Espanol if need 1 significant digit
-- `1234` is converted to `1234` in Japanese (yeah weird I know!)
+- `1234` is converted to `1234` in Japanese
 
 Utilizes [cldr-numbers-full](https://github.com/unicode-cldr/cldr-numbers-full). Here is the related proposal for [Compact Decimal Format](https://github.com/tc39/ecma402/issues/37) that this addon is based on.  This is why there are no browser API's baked into something like `Intl.NumberFormat`.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Short number formatting based on CLDR locale data.  Particularly useful for __st
 - `101234` is converted to `101K` in English and `101.1K` if need 1 significant digit
 - `1234` is converted to `1 mil` in Espanol
 - `101234` is converted to `101,1 mil` in Espanol if need 1 significant digit
-- `1234` is converted to `1` in Japanese (yeah weird I know!)
+- `1234` is converted to `1234` in Japanese (yeah weird I know!)
 
 Utilizes [cldr-numbers-full](https://github.com/unicode-cldr/cldr-numbers-full). Here is the related proposal for [Compact Decimal Format](https://github.com/tc39/ecma402/issues/37) that this addon is based on.  This is why there are no browser API's baked into something like `Intl.NumberFormat`.
 
@@ -35,15 +35,15 @@ let ENV = {
 }
 ```
 
-**threshold**
+### threshold
 
 This configuration option decides when to round up the formatted number.  So if you pass 95001, `ember-short-number` will output 100K.  However, if you pass 94999, you will get back 95K.
 
 Usage
 ------------------------------------------------------------------------------
-Note - the following APIs take the language code as the the second argument based on [ISO 639-1](http://www.loc.gov/standards/iso639-2/php/code_list.php)
+The following APIs take the language code as the the second argument based on [ISO 639-1](http://www.loc.gov/standards/iso639-2/php/code_list.php).  You can also pass `en_GB` or `en-GB` and we will normalize it to `en` as well.
 
-**Template Helper**
+### Template Helper
 
 ```hbs
 {{short-number 19634 "en"}}
@@ -66,7 +66,7 @@ Note - the following APIs take the language code as the the second argument base
 ```
 
 
-Alternatively use the **Service API**
+### Service API
 
 ```js
 this.shortNumber.format(19634, 'en');
@@ -96,7 +96,7 @@ this.shortNumber.format(19634, 'es', { significantDigits: 1 });
 * Note when using significantDigits, this addon utilizes [`toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString).
 
 
-**Long Formatting**
+### Long Formatting
 
 "Wait, I thought this addon was for compact number formatting?" Well it can be a misnomer depending on the language.  Let's look at some examples.
 

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -1,7 +1,7 @@
 /**
  * @method replaceNumber
  * @param {Number} number
- * @param {String} String
+ * @param {String} format
  * @return {String}
  */
 export function replaceNumber(number, format) {
@@ -24,3 +24,14 @@ export function normalizeLocal(locale) {
   return locale;
 }
 
+/**
+ * If rule only contains 0, it indicates no short number formatting applied
+ * e.g. "ja" 1234 -> 1234 and not 1K
+ *
+ * @method needsFormatting
+ * @param {String} format
+ * @return {String}
+ */
+export function needsFormatting(format) {
+  return format.match(/[^0]/);
+}

--- a/addon/services/short-number.js
+++ b/addon/services/short-number.js
@@ -3,7 +3,7 @@ import { getOwner } from '@ember/application';
 import { set } from '@ember/object';
 import hydrate from '../-private/hydrate';
 import { isLessThanBoundary, extractIntPart, normalizeNumber } from '../-private/math-utils';
-import { replaceNumber, normalizeLocal } from '../-private/utils';
+import { replaceNumber, normalizeLocal, needsFormatting } from '../-private/utils';
 
 export default Service.extend({
   __localeData__: null,
@@ -121,6 +121,10 @@ export default Service.extend({
     let [range, opts] = matchingRule;
     // cldr data is either `one` or `other`.  Defaulting to `one` for now
     let [format, numberOfDigits] = opts.one || opts.other;
+
+    if (!needsFormatting(format)) {
+      return value;
+    }
 
     let normalized = normalizeNumber(
       extractIntPart(number, range, numberOfDigits),

--- a/tests/integration/helpers/short-number-test.js
+++ b/tests/integration/helpers/short-number-test.js
@@ -449,7 +449,11 @@ module('Integration | Helper | short-number', function(hooks) {
 
       await render(hbs`{{short-number 95001 "ja" long=true}}`);
 
-      assert.equal(this.element.textContent.trim(), '10万', '100000 in japanese');
+      assert.equal(this.element.textContent.trim(), '10万', '95000 in japanese');
+
+      await render(hbs`{{short-number 95001 "ja" long=true significantDigits=1}}`);
+
+      assert.equal(this.element.textContent.trim(), '9.5万', '95000 in japanese');
 
       await render(hbs`{{short-number 101000 "ja" long=true}}`);
 

--- a/tests/integration/helpers/short-number-test.js
+++ b/tests/integration/helpers/short-number-test.js
@@ -319,7 +319,7 @@ module('Integration | Helper | short-number', function(hooks) {
 
     await render(hbs`{{short-number 1234 "ja"}}`);
 
-    assert.equal(this.element.textContent.trim(), '1');
+    assert.equal(this.element.textContent.trim(), '1234');
 
     await render(hbs`{{short-number 11634 "ja" significantDigits=1}}`);
 
@@ -328,6 +328,32 @@ module('Integration | Helper | short-number', function(hooks) {
     await render(hbs`{{short-number 19234 "ja"}}`);
 
     assert.equal(this.element.textContent.trim(), '2万');
+
+    await render(hbs`{{short-number 23234 "ja" significantDigits=1}}`);
+
+    assert.equal(this.element.textContent.trim(), '2.3万');
+
+    await render(hbs`{{short-number 94999 "ja"}}`);
+
+    assert.equal(this.element.textContent.trim(), '9万');
+
+    await render(hbs`{{short-number 95001 "ja"}}`);
+
+    assert.equal(this.element.textContent.trim(), '10万', '100000 in japanese');
+
+    await render(hbs`{{short-number 101000 "ja"}}`);
+
+    assert.equal(this.element.textContent.trim(), '10万', '101000 in japanese');
+
+    await render(hbs`{{short-number 1000000 "ja"}}`);
+
+    assert.equal(this.element.textContent.trim(), '100万', '1 million in japanese');
+
+    await render(hbs`{{short-number 10000000 "ja"}}`);
+
+    assert.equal(this.element.textContent.trim(), '1000万', '10 million in japanese');
+
+    await render(hbs`{{short-number 99000000 "ja"}}`);
 
     await render(hbs`{{short-number 11119234 "ja"}}`);
 
@@ -403,9 +429,9 @@ module('Integration | Helper | short-number', function(hooks) {
 
       await render(hbs`{{short-number 1234 "ja" long=true}}`);
 
-      assert.equal(this.element.textContent.trim(), '1');
+      assert.equal(this.element.textContent.trim(), '1234');
 
-      await render(hbs`{{short-number 11634 "ja" significantDigits=1}}`);
+      await render(hbs`{{short-number 11634 "ja" significantDigits=1 long=true}}`);
 
       assert.equal(this.element.textContent.trim(), '1.2万');
 
@@ -413,9 +439,41 @@ module('Integration | Helper | short-number', function(hooks) {
 
       assert.equal(this.element.textContent.trim(), '2万');
 
+      await render(hbs`{{short-number 23234 "ja" significantDigits=1 long=true}}`);
+
+      assert.equal(this.element.textContent.trim(), '2.3万');
+
+      await render(hbs`{{short-number 94999 "ja" long=true}}`);
+
+      assert.equal(this.element.textContent.trim(), '9万');
+
+      await render(hbs`{{short-number 95001 "ja" long=true}}`);
+
+      assert.equal(this.element.textContent.trim(), '10万', '100000 in japanese');
+
+      await render(hbs`{{short-number 101000 "ja" long=true}}`);
+
+      assert.equal(this.element.textContent.trim(), '10万', '101000 in japanese');
+
+      await render(hbs`{{short-number 1000000 "ja" long=true}}`);
+
+      assert.equal(this.element.textContent.trim(), '100万', '1 million in japanese');
+
+      await render(hbs`{{short-number 10000000 "ja" long=true}}`);
+
+      assert.equal(this.element.textContent.trim(), '1000万', '10 million in japanese');
+
+      await render(hbs`{{short-number 99000000 "ja" long=true}}`);
+
+      assert.equal(this.element.textContent.trim(), '1億', '100 million in japanese');
+
       await render(hbs`{{short-number 11119234 "ja" long=true}}`);
 
-      assert.equal(this.element.textContent.trim(), '1112万');
+      assert.equal(this.element.textContent.trim(), '1112万', '11 million in japanese long format');
+
+      await render(hbs`{{short-number -11119234 "ja" long=true}}`);
+
+      assert.equal(this.element.textContent.trim(), '-1112万', 'negative 11 million in japanese long format');
     });
   });
 });


### PR DESCRIPTION
"ja" `1234` -> `1234` and not `1`

https://github.com/unicode-cldr/cldr-numbers-full/blob/master/main/ja/numbers.json#L53