### PR TITLE
Recursively figure out parentLocale

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This configuration option decides when to round up the formatted number.  So if 
 
 Usage
 ------------------------------------------------------------------------------
-The following APIs take the language code as the the second argument based on [ISO 639-1](http://www.loc.gov/standards/iso639-2/php/code_list.php).  You can also pass `en_GB` or `en-GB` and we will normalize it to `en` as well.
+The following APIs take the language code as the the second argument based on [ISO 639-1](http://www.loc.gov/standards/iso639-2/php/code_list.php).  You can also pass `en_GB` and we will normalize it to `en-GB` as well.
 
 ### Template Helper
 

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -17,11 +17,7 @@ export function replaceNumber(number, format) {
  * @return {String}
  */
 export function normalizeLocal(locale) {
-  let match = locale.match(/_|-/);
-  if (match) {
-    return locale.split(match[0])[0];
-  }
-  return locale;
+  return locale.replace(/_/, '-').toLowerCase();
 }
 
 /**
@@ -34,4 +30,26 @@ export function normalizeLocal(locale) {
  */
 export function needsFormatting(format) {
   return format.match(/[^0]/);
+}
+
+/**
+ * @method findParentLocale
+ * @param {Object} localeData
+ * @param {String} locale
+ * @return {String}
+ */
+export function findParentLocale(localeData, locale) {
+  let topLevelData = localeData[locale];
+  if (!topLevelData) {
+    return;
+  }
+
+  let numbersHash = topLevelData.numbers;
+  let parentLocale = topLevelData.parentLocale;
+
+  if (!numbersHash && parentLocale) {
+    numbersHash = findParentLocale(localeData, parentLocale);
+  }
+
+  return numbersHash;
 }

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -33,12 +33,12 @@ export function needsFormatting(format) {
 }
 
 /**
- * @method findParentLocale
+ * @method findLocaleDate
  * @param {Object} localeData
  * @param {String} locale
  * @return {String}
  */
-export function findParentLocale(localeData, locale) {
+export function findLocaleDate(localeData, locale) {
   let topLevelData = localeData[locale];
   if (!topLevelData) {
     return;
@@ -48,7 +48,7 @@ export function findParentLocale(localeData, locale) {
   let parentLocale = topLevelData.parentLocale;
 
   if (!numbersHash && parentLocale) {
-    numbersHash = findParentLocale(localeData, parentLocale);
+    numbersHash = findLocaleDate(localeData, parentLocale);
   }
 
   return numbersHash;

--- a/tests/integration/helpers/short-number-test.js
+++ b/tests/integration/helpers/short-number-test.js
@@ -223,10 +223,6 @@ module('Integration | Helper | short-number', function(hooks) {
 
     assert.equal(replaceWhitespace(this.element.textContent.trim()), '19 mil');
 
-    await render(hbs`{{short-number 19234 "es-MX"}}`);
-
-    assert.equal(replaceWhitespace(this.element.textContent.trim()), '19 mil');
-
     await render(hbs`{{short-number 101000 "es"}}`);
 
     assert.equal(replaceWhitespace(this.element.textContent.trim()), '101 mil');
@@ -266,6 +262,68 @@ module('Integration | Helper | short-number', function(hooks) {
     await render(hbs`{{short-number "-19234.9" "es"}}`);
 
     assert.equal(replaceWhitespace(this.element.textContent.trim()), '-19 mil');
+  });
+
+  test('it renders "es-MX"', async function(assert) {
+    await render(hbs`{{short-number 234 "es-MX"}}`);
+
+    assert.equal(this.element.textContent.trim(), '234');
+
+    await render(hbs`{{short-number 1234 "es-MX"}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '1 k');
+
+    await render(hbs`{{short-number 1234.23 "es-MX"}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '1 k');
+
+    await render(hbs`{{short-number 19234 "es-MX"}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '19 k');
+
+    await render(hbs`{{short-number 19234 "es-MX"}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '19 k');
+
+    await render(hbs`{{short-number 101000 "es-MX"}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '101 k');
+
+    await render(hbs`{{short-number 101000 "es-MX" significantDigits=1 financialFormat=true}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '0.1 M');
+
+    await render(hbs`{{short-number 949949 "es-MX" significantDigits=1}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '949.9 k', 'greater than 5% threshold and does not round up');
+
+    await render(hbs`{{short-number 949949 "es-MX" significantDigits=2}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '949.95 k', 'greater than 5% threshold and does not round up');
+
+    await render(hbs`{{short-number 949999 "es-MX" significantDigits=1}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '950 k', 'greater than 5% threshold so still use 100K rules');
+
+    await render(hbs`{{short-number 995000 "es-MX" significantDigits=1}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '1 M', 'within 5% threshold so no significant digits');
+
+    await render(hbs`{{short-number 999949 "es-MX" significantDigits=1}}`);
+
+    assert.equal(this.element.textContent.trim().replace(/\s+/, ' '), '1 M');
+
+    await render(hbs`{{short-number 11119234 "es-MX"}}`);
+
+    assert.equal(this.element.textContent.trim().replace(/\s+/, ' '), '11 M');
+
+    await render(hbs`{{short-number "-19234" "es-MX"}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '-19 k', 'renders negative number');
+
+    await render(hbs`{{short-number "-19234.9" "es-MX"}}`);
+
+    assert.equal(replaceWhitespace(this.element.textContent.trim()), '-19 k');
   });
 
   test('it renders "ks"', async function(assert) {

--- a/tests/unit/services/short-number-test.js
+++ b/tests/unit/services/short-number-test.js
@@ -65,5 +65,8 @@ module('Unit | Service | short-number', function(hooks) {
 
     formattedNumber = service.format('1234', 'en_GB');
     assert.equal(formattedNumber, '1K');
+
+    formattedNumber = service.format('1234', 'en_xx');
+    assert.equal(formattedNumber, '1234', 'it doesnt format if lang not found');
   });
 });


### PR DESCRIPTION
Applicable data is found only when the locale specific hash has a numbers property