### PR TITLE
Update cldr to 0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@ember-intl/broccoli-cldr-data": "~3.1.0",
-    "cldr-compact-number": "0.2.1",
+    "cldr-compact-number": "~0.2.2",
     "ember-auto-import": "^1.2.15",
     "ember-cli-babel": "^6.16.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@ember-intl/broccoli-cldr-data": "~3.1.0",
-    "cldr-compact-number": "0.2.0",
+    "cldr-compact-number": "0.2.1",
     "ember-auto-import": "^1.2.15",
     "ember-cli-babel": "^6.16.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@ember-intl/broccoli-cldr-data": "~3.1.0",
-    "cldr-compact-number": "0.1.1",
+    "cldr-compact-number": "0.2.0",
     "ember-auto-import": "^1.2.15",
     "ember-cli-babel": "^6.16.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,10 +2046,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cldr-compact-number@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/cldr-compact-number/-/cldr-compact-number-0.1.1.tgz#7d234236fcfec517d832a9b1a586fdfc7accebae"
-  integrity sha512-2f2gwu2ejkoUdcQmRKuf2FZA2q4N9gBYhQEDLrUsxhgcyzjEyVh43kigc2W+Q7B7INh2YZ8H/qsZmyfKEF8SQg==
+cldr-compact-number@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/cldr-compact-number/-/cldr-compact-number-0.2.0.tgz#9e58e987aceeea38106f3a663076fc0a616d0290"
+  integrity sha512-tF/0nol4B47k5O5qjij07V6G8ZFjOn+8YX34QYo6TqU0DX9KkMdf9xsQHE/199q6DSMkwn4OSl/e1oUJD8kBAA==
 
 cldr-core@^34.0.0:
   version "34.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,10 +2046,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cldr-compact-number@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/cldr-compact-number/-/cldr-compact-number-0.2.1.tgz#912bb336009ed7193609acbb1338303c86d4118b"
-  integrity sha512-lmYdUvlFDufDI4RPmU2R5+PA2MKwp4/y29OvyL6CFX14Y0K+5RWxoQ89StAeb1fYlEznG8ywyHxWU60i+rYZqg==
+cldr-compact-number@~0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cldr-compact-number/-/cldr-compact-number-0.2.2.tgz#57008baa2f2ddb45348e2becb3aa053d8a344494"
+  integrity sha512-ZFoI6bUhft5uDe7QOvo1howSXixVsrLx/8nvSiXfGSbKnH1OGlXOU1HZNu9pXPYY5Zbu/tPTylpRTwZ6I7QnoQ==
 
 cldr-core@^34.0.0:
   version "34.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,10 +2046,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cldr-compact-number@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/cldr-compact-number/-/cldr-compact-number-0.2.0.tgz#9e58e987aceeea38106f3a663076fc0a616d0290"
-  integrity sha512-tF/0nol4B47k5O5qjij07V6G8ZFjOn+8YX34QYo6TqU0DX9KkMdf9xsQHE/199q6DSMkwn4OSl/e1oUJD8kBAA==
+cldr-compact-number@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cldr-compact-number/-/cldr-compact-number-0.2.1.tgz#912bb336009ed7193609acbb1338303c86d4118b"
+  integrity sha512-lmYdUvlFDufDI4RPmU2R5+PA2MKwp4/y29OvyL6CFX14Y0K+5RWxoQ89StAeb1fYlEznG8ywyHxWU60i+rYZqg==
 
 cldr-core@^34.0.0:
   version "34.0.0"


### PR DESCRIPTION
Actually export es5 if need be while still have umd option.

https://github.com/snewcomer/cldr-compact-number/pull/4